### PR TITLE
fix DeviceSettings mismatched tag

### DIFF
--- a/DeviceSettings/AndroidManifest.xml
+++ b/DeviceSettings/AndroidManifest.xml
@@ -55,11 +55,11 @@
         <activity android:name=".DeviceSettings" />
         <activity android:name=".KeyHandler" />
 
-        <activity
+        <!-- <activity
             android:name=".TouchscreenGestureSettings"
             android:label="@string/touchscreen_gesture_settings_title"
             android:theme="@style/AppTheme">
-        </activity>
+        </activity> -->
 
         <receiver android:name="org.aosp.device.DeviceSettings.Startup" >
             <intent-filter android:priority="100" >

--- a/DeviceSettings/res/xml/main.xml
+++ b/DeviceSettings/res/xml/main.xml
@@ -40,7 +40,6 @@
             android:title="@string/auto_hbm_threshold_title"
             android:summary="@string/auto_hbm_threshold_summary" />
 
-        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -75,7 +74,7 @@
           android:entryValues="@array/notification_slider_action_entry_values" />
     </PreferenceCategory>
 
-    <PreferenceCategory
+    <!-- <PreferenceCategory
         android:key="screenoffgestures"
         android:title="@string/touch_title">
         <Preference
@@ -86,6 +85,7 @@
             <intent android:action="android.intent.action.MAIN"
                     android:targetPackage="org.aosp.device.DeviceSettings"
                     android:targetClass="org.aosp.device.DeviceSettings.TouchscreenGestureSettings" />
-    </PreferenceCategory>
+        </Preference>
+    </PreferenceCategory> -->
 
 </PreferenceScreen>

--- a/DeviceSettings/src/org/aosp/device/DeviceSettings/Startup.java
+++ b/DeviceSettings/src/org/aosp/device/DeviceSettings/Startup.java
@@ -15,7 +15,7 @@
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 *
 */
-package org.aosp.device.DeviceSettings;
+/*package org.aosp.device.DeviceSettings;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -69,4 +69,4 @@ public class Startup extends BroadcastReceiver {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
         preferences.edit().putBoolean(ONE_TIME_TUNABLE_RESTORE, true).apply();
     }
-}
+}*/

--- a/DeviceSettings/src/org/aosp/device/DeviceSettings/TouchscreenGestureSettings.java
+++ b/DeviceSettings/src/org/aosp/device/DeviceSettings/TouchscreenGestureSettings.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.aosp.device.DeviceSettings;
+/*package org.aosp.device.DeviceSettings;
 
 import android.app.ActionBar;
 import android.app.Fragment;
@@ -254,4 +254,4 @@ public class TouchscreenGestureSettings extends PreferenceActivity
         }
         return super.onOptionsItemSelected(item);
     }
-}
+}*/


### PR DESCRIPTION
fix DeviceSettings mismatched tag

diff --git a/DeviceSettings/res/xml/main.xml b/DeviceSettings/res/xml/main.xml
index d72b5b3..5c173be 100644
--- a/DeviceSettings/res/xml/main.xml
+++ b/DeviceSettings/res/xml/main.xml
@@ -40,7 +40,6 @@
             android:title="@string/auto_hbm_threshold_title"
             android:summary="@string/auto_hbm_threshold_summary" />
 
-        </Preference>
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -86,6 +85,7 @@
             <intent android:action="android.intent.action.MAIN"
                     android:targetPackage="org.aosp.device.DeviceSettings"
                     android:targetClass="org.aosp.device.DeviceSettings.Touchsc
reenGestureSettings" />
+        </Preference>
     </PreferenceCategory>
 
 </PreferenceScreen>